### PR TITLE
Sans NSORT equivalent

### DIFF
--- a/.github/workflows/webworker_build.yml
+++ b/.github/workflows/webworker_build.yml
@@ -53,6 +53,7 @@ jobs:
   deploy:
     # Add a dependency to the build job
     needs: build
+    if: ${{ github.event_name != 'pull_request' }}
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/reductus/sansred/sansdata.py
+++ b/reductus/sansred/sansdata.py
@@ -269,8 +269,9 @@ class SansIQData(object):
         self.label = label
         self.metadata = metadata if metadata is not None else {}
         self._q_point_cutoffs: (int, int) = None
+        self.scaling_factor: float = 1.0
 
-    def q_cutoff(self) -> SansIQData:
+    def q_cutoff(self):
         if self._q_point_cutoffs is None:
             # If no limits have been set, no truncation
             self._q_point_cutoffs = (0, -1)

--- a/reductus/sansred/sansdata.py
+++ b/reductus/sansred/sansdata.py
@@ -428,7 +428,7 @@ class SansIQData(object):
         # Determine order of Q values based in current index
         indices = np.argsort(self.Q)
         # Reorder Q array using the indices
-        self.Q[indices]
+        self.Q = self.Q[indices]
         # Concatenate and reorder remaining data arrays if they exist in both data sets
         self.I = np.concatenate((self.I, data.I))[indices]
         if self.dI is not None and data.dI is not None:

--- a/reductus/sansred/sansdata.py
+++ b/reductus/sansred/sansdata.py
@@ -281,14 +281,15 @@ class Sans1dData(object):
 
 class SansIQData(object):
     def __init__(self, I=None, dI=None, Q=None, dQ=None, meanQ=None, ShadowFactor=None, label='', metadata=None):
-        self.I = I if I is not None else np.zeros_like(0)
-        self.dI = dI if dI is not None else np.zeros_like(0)
-        self.Q = Q if Q is not None else np.zeros_like(0)
-        self.dQ = dQ if dQ is not None else np.zeros_like(0)
-        self.meanQ = meanQ if meanQ is not None else np.zeros_like(0)
-        self.ShadowFactor = ShadowFactor if ShadowFactor is not None else np.zeros_like(0)
-        self.label = label
-        self.metadata = metadata if metadata is not None else {}
+        shape = np.shape(Q) if Q is not None else 0
+        self.I: np.ndarray = I if I is not None else np.empty(shape)
+        self.dI: np.ndarray = dI if dI is not None else np.empty(shape)
+        self.Q: np.ndarray = Q if Q is not None else np.empty(shape)
+        self.dQ: np.ndarray = dQ if dQ is not None else np.empty(shape)
+        self.meanQ: np.ndarray = meanQ if meanQ is not None else np.empty(shape)
+        self.ShadowFactor: np.ndarray = ShadowFactor if ShadowFactor is not None else np.empty(shape)
+        self.label: str = label
+        self.metadata: dict[str, str | int | float | list] = metadata if metadata is not None else {}
         self._q_mask: list[int] | None = None
 
     def q_cutoff(self):

--- a/reductus/sansred/sansdata.py
+++ b/reductus/sansred/sansdata.py
@@ -308,11 +308,13 @@ class SansIQData(object):
 
     @property
     def mask(self):
-        return self.q_cutoff()
+        return self._q_mask
 
     @mask.setter
     def mask(self, masked_points: list[int] | None = None):
-        # Allow the user to either send an integer index or a Q value. The chance a Q value being a whole number is low
+        # masked_points should be a list of self.Q indices that are to be excluded from calcaulations
+        if masked_points is not None and min(masked_points) < 0 and max(masked_points) >= len(self.Q):
+            raise ValueError("The masked indices are out of range of the Q data.")
         self._q_mask = masked_points
     
     def get_plottable(self):

--- a/reductus/sansred/sansdata.py
+++ b/reductus/sansred/sansdata.py
@@ -290,7 +290,6 @@ class SansIQData(object):
         self.label = label
         self.metadata = metadata if metadata is not None else {}
         self._q_mask: list[int] | None = None
-        self.scaling_factor: float = 1.0
 
     def q_cutoff(self):
         if self._q_mask is None:

--- a/reductus/sansred/sansdata.py
+++ b/reductus/sansred/sansdata.py
@@ -403,24 +403,24 @@ class SansIQData(object):
             "value": h5_item,
         }
 
-    def append_1d_data_set(self, data: SansIQData):
+    def append_1d_data_set(self, data):
         """Concatenate another data set with the existing one. The resulting data arrays will be sorted """
         # Create concatenated Q array
-        self.Q.concatenate(data.Q)
+        self.Q = np.concatenate((self.Q, data.Q))
         # Determine order of Q values based in current index
         indices = np.argsort(self.Q)
         # Reorder Q array using the indices
-        self.Q.sort(order=indices)
+        self.Q[indices]
         # Concatenate and reorder remaining data arrays if they exist in both data sets
-        self.I.concatenate(data.I).sort(order=indices)
+        self.I = np.concatenate((self.I, data.I))[indices]
         if self.dI is not None and data.dI is not None:
-            self.dI.concatenate(data.dI).sort(order=indices)
+            self.dI = np.concatenate((self.dI, data.dI))[indices]
         if self.dQ is not None and data.dQ is not None:
-            self.dQ.concatenate(data.dQ).sort(order=indices)
+            self.dQ = np.concatenate((self.dQ, data.dQ))[indices]
         if self.meanQ is not None and data.meanQ is not None:
-            self.meanQ.concatenate(data.meanQ).sort(order=indices)
+            self.meanQ = np.concatenate((self.meanQ, data.meanQ))[indices]
         if self.ShadowFactor is not None and data.ShadowFactor is not None:
-            self.ShadowFactor.concatenate(data.ShadowFactor).sort(order=indices)
+            self.ShadowFactor = np.concatenate((self.ShadowFactor, data.ShadowFactor))[indices]
 
 
 class Parameters(object):

--- a/reductus/sansred/steps.py
+++ b/reductus/sansred/steps.py
@@ -2101,25 +2101,31 @@ def scale_by_factor(data_to_scale: SansIQData | Sans1dData, scaling_factor: floa
 
 
 @module
-def set_q_limits(data: SansIQData | Sans1dData, lower_q: float = 0, upper_q: float = -1) -> SansIQData | Sans1dData:
-    """Scale a data set relative to another data set.
+def mask_1d_data(data: SansIQData | Sans1dData, mask_indices: list[int] = None) -> SansIQData | Sans1dData:
+    """
+    Identify and mask out user-specified points.
+
+    This defines the *mask* attribute of *data* to include all data
+    except those indicated in *mask_indices*.  Any previous mask is cleared.
+    The masked data are not actually removed from the data, since this
+    operation is done by *join*.
 
     **Inputs**
 
-    data (sans1d): SANS 1D to be scaled
+    data (sans1d) : background data which may contain specular point
 
-    lower_q (float): The lowest Q value to accept from the data set
-
-    upper_q (float): The highest Q value to accept from the data set
+    mask_indices (index[]*) : 0-origin data point indices to mask. For example,
+    *mask_indices=[1,4,6]* masks the 2nd, 5th and 7th point respectively. Each
+    dataset should have its own mask.
 
     **Returns**
 
-    output(sans1d): A scaled 1D SANS data set
+    output (sans1d) : masked data
 
-    | 2025-07-30 Jeff Krzywon initial implementation
-
+    | 2025-08-01 Jeff Krzywon: initial port of refl mask_points
     """
-    data.set_q_limits(lower_q, upper_q)
+    data = copy(data)
+    data.mask = mask_indices
     return data.q_cutoff()
 
 

--- a/reductus/sansred/steps.py
+++ b/reductus/sansred/steps.py
@@ -1134,6 +1134,41 @@ def rescale_1d(data, scale=1.0, dscale=0.0):
 
 
 @module
+def shift_1d(data, shift=1.0, dshift=0.0):
+    """
+    Multiply 1d data by a scale factor
+
+    **Inputs**
+
+    data (sans1d): data in
+
+    shift (float) : amount to shift, one for each dataset
+
+    dshift {Scale err} (float:<0,inf>) : scale uncertainty for gaussian error propagation
+
+    **Returns**
+
+    output (sans1d) : shifted data
+
+    2025-08-05 Jeff Krzywon
+    """
+    from reductus.dataflow.lib import err1d
+
+    # Allow for either raw or reduced data without having to differentiate upfront
+    intensity = data.v if hasattr(data, 'v') else data.I
+    uncertainty = data.dv if hasattr(data, 'dv') else data.dI
+
+    # TODO: FIXME
+    I, varI = err1d.add(intensity, uncertainty, shift, dshift**2)
+    if hasattr(data, 'v'):
+        data.v, data.dv = I, varI
+    else:
+        data.I, data.dI = I, varI
+
+    return data
+
+
+@module
 def correct_detector_efficiency(sansdata):
     """
     Given a SansData object, corrects for the efficiency of the detection process
@@ -2076,8 +2111,8 @@ def scale_to_data(data_to_scale: SansIQData | Sans1dData, data_to_scale_by: Sans
     scaling_factor = 1.0
     if data_to_scale_by is not None:
         scaling_factor = _get_scaling_factor_between_data(data_to_scale, data_to_scale_by)
-    data_to_scale.scaling_factor = scaling_factor
-    return data_to_scale
+    new_data = rescale_1d(data_to_scale, scaling_factor)
+    return new_data
 
 
 @module
@@ -2097,6 +2132,49 @@ def scale_by_factor(data_to_scale: SansIQData | Sans1dData, scaling_factor: floa
     | 2025-07-30 Jeff Krzywon initial implementation
     """
     new_data = rescale_1d(data_to_scale, scaling_factor)
+    return new_data
+
+
+@module
+def shift_to_data(data_to_shift: SansIQData | Sans1dData, data_to_shift_to: SansIQData | Sans1dData) -> SansIQData | Sans1dData:
+    """Scale a data set relative to another data set.
+
+    **Inputs**
+
+    data_to_shift (sans1d): SANS 1D where the intensity is to be shifted by a fixed amount on all Q values
+
+    data_to_shift_to (sans1d): SANS 1D the data set should be shifted to match
+
+    **Returns**
+
+    output(sans1d): A 1D SANS data set that has been shifted
+
+    | 2025-08-05 Jeff Krzywon initial implementation
+    """
+    shifting_factor = 0.0
+    if data_to_shift_to is not None:
+        shifting_factor = _get_shifting_factor_between_data(data_to_shift, data_to_shift_to)
+    new_data = shift_1d(data_to_shift, shifting_factor)
+    return new_data
+
+
+@module
+def shift_by_factor(data_to_shift: SansIQData | Sans1dData, shifting_factor: float = 0.0) -> SansIQData | Sans1dData:
+    """Scale a data set relative to another data set.
+
+    **Inputs**
+
+    data_to_shift (sans1d): SANS 1D to be scaled
+
+    shifting_factor (float): The factor to scale a dataset by
+
+    **Returns**
+
+    output(sans1d): A scaled 1D SANS data set
+
+    | 2025-08-05 Jeff Krzywon initial implementation
+    """
+    new_data = shift_1d(data_to_shift, shifting_factor)
     return new_data
 
 
@@ -2195,3 +2273,29 @@ def _get_scaling_factor_between_data(scale_to_data: np.ndarray, data_to_be_scale
     # Sum all values in the sliced section
     # Divide scale_to_data sum by data_to_be_scaled sum
     return numerator / denominator
+
+
+def _get_shifting_factor_between_data(scale_to_data: np.ndarray, data_to_be_scaled: np.ndarray) -> float:
+    """Find the overlap region between two numerical arrays, and average difference between the regions
+
+    :param scale_to_data: A numerical array
+    """
+
+    if min(data_to_be_scaled) > min(scale_to_data):
+        # Overlap is on the high-Q end of the data to be scaled
+        scale_to_upper_index = np.where(scale_to_data == _find_nearest(scale_to_data, np.max(data_to_be_scaled)))[0]
+        scaled_lower_index = np.where(data_to_be_scaled == _find_nearest(data_to_be_scaled, np.min(scale_to_data)))[0]
+        a = np.sum(data_to_be_scaled[scaled_lower_index:])
+        b = np.sum(scale_to_data[:scale_to_upper_index])
+        npts = len(data_to_be_scaled) - scaled_lower_index
+    else:
+        # Overlap is on the low-Q end of the data to be scaled
+        scaled_upper_index = np.where(scale_to_data == _find_nearest(scale_to_data, np.min(data_to_be_scaled)))[0]
+        scale_to_lower_index = np.where(data_to_be_scaled == _find_nearest(data_to_be_scaled, np.max(scale_to_data)))[0]
+        a = np.sum(data_to_be_scaled[:scaled_upper_index])
+        b = np.sum(scale_to_data[scale_to_lower_index:])
+        npts = scaled_upper_index
+    # Slice data at limits after determining if you slice the upper or lower section
+    # Sum all values in the sliced section
+    # Divide scale_to_data sum by data_to_be_scaled sum
+    return (a - b) / npts

--- a/reductus/sansred/steps.py
+++ b/reductus/sansred/steps.py
@@ -1119,10 +1119,18 @@ def rescale_1d(data, scale=1.0, dscale=0.0):
     """
     from reductus.dataflow.lib import err1d
 
-    I, varI = err1d.mul(data.v, data.dv, scale, dscale**2)
-    data.v, data.dv = I, varI
+    # Allow for either raw or reduced data without having to differentiate upfront
+    intensity = data.v if hasattr(data, 'v') else data.I
+    uncertainty = data.dv if hasattr(data, 'dv') else data.dI
+
+    I, varI = err1d.mul(intensity, uncertainty, scale, dscale**2)
+    if hasattr(data, 'v'):
+        data.v, data.dv = I, varI
+    else:
+        data.I, data.dI = I, varI
     
     return data
+
 
 @module
 def correct_detector_efficiency(sansdata):

--- a/reductus/sansred/steps.py
+++ b/reductus/sansred/steps.py
@@ -1522,13 +1522,13 @@ def absolute_scaling(empty, sample, Tsam, div, instrument="NG7", integration_box
 
     **Inputs**
 
-    empty (sans2d): measurement with no sample in the beam
-
     sample (sans2d): measurement with sample in the beam
+
+    div (sans2d): DIV measurement
 
     Tsam (params): sample transmission
 
-    div (sans2d): DIV measurement
+    empty (sans2d): measurement with no sample in the beam
 
     instrument (opt:NG7|NGB|NGB30): instrument name, should be NG7 or NG3
 
@@ -1548,6 +1548,7 @@ def absolute_scaling(empty, sample, Tsam, div, instrument="NG7", integration_box
     | 2017-01-13 Andrew Jackson
     | 2019-07-04 Brian Maranville
     | 2019-07-14 Brian Maranville
+    | 2025-07-17 Jeff Krzywon
     """
         # data (that is going through reduction), empty beam,
     # div, Transmission of the sample, instrument(NG3.NG5, NG7)

--- a/reductus/sansred/steps.py
+++ b/reductus/sansred/steps.py
@@ -2058,6 +2058,72 @@ def getPoissonUncertainty(y):
 
 
 @module
+def scale_to_data(data_to_scale: SansIQData | Sans1dData, data_to_scale_by: SansIQData | Sans1dData) -> SansIQData | Sans1dData:
+    """Scale a data set relative to another data set.
+
+    **Inputs**
+
+    data_to_scale (sans1d): SANS 1D to be scaled
+
+    data_to_scale_by (sans1d): SANS 1D the data set should be scaled to
+
+    **Returns**
+
+    output(sans1d): A scaled 1D SANS data set
+
+    | 2025-07-30 Jeff Krzywon initial implementation
+    """
+    scaling_factor = 1.0
+    if data_to_scale_by is not None:
+        scaling_factor = _get_scaling_factor_between_data(data_to_scale, data_to_scale_by)
+    data_to_scale.scaling_factor = scaling_factor
+    return data_to_scale
+
+
+@module
+def scale_by_factor(data_to_scale: SansIQData | Sans1dData, scaling_factor: float = 1.0) -> SansIQData | Sans1dData:
+    """Scale a data set relative to another data set.
+
+    **Inputs**
+
+    data_to_scale (sans1d): SANS 1D to be scaled
+
+    scaling_factor (float): The factor to scale a dataset by
+
+    **Returns**
+
+    output(sans1d): A scaled 1D SANS data set
+
+    | 2025-07-30 Jeff Krzywon initial implementation
+    """
+    new_data = rescale_1d(data_to_scale, scaling_factor)
+    return new_data
+
+
+@module
+def set_q_limits(data: SansIQData | Sans1dData, lower_q: float = 0, upper_q: float = -1) -> SansIQData | Sans1dData:
+    """Scale a data set relative to another data set.
+
+    **Inputs**
+
+    data (sans1d): SANS 1D to be scaled
+
+    lower_q (float): The lowest Q value to accept from the data set
+
+    upper_q (float): The highest Q value to accept from the data set
+
+    **Returns**
+
+    output(sans1d): A scaled 1D SANS data set
+
+    | 2025-07-30 Jeff Krzywon initial implementation
+
+    """
+    data.set_q_limits(lower_q, upper_q)
+    return data.q_cutoff()
+
+
+@module
 def sort_n_data_sets(data: [SansIQData]):
     """A module that allows the user to combine multiple reduced 1D data sets together. This is a similar process to the
     NSORT function in the Igor Pro macros. This will optionally scale each data set by a defined amount and then exclude

--- a/reductus/sansred/templates/ncnr.sans.default.json
+++ b/reductus/sansred/templates/ncnr.sans.default.json
@@ -182,6 +182,12 @@
           72
         ]
       }
+    },
+    {
+      "x": 1375,
+      "module": "ncnr.sans.mask_1d_data",
+      "y": 35,
+      "title": "Trim Points"
     }
   ],
   "wires": [
@@ -383,6 +389,16 @@
       "target": [
         16,
         "empty_beam"
+      ]
+    },
+    {
+      "source": [
+        13,
+        "output"
+      ],
+      "target": [
+        17,
+        "data"
       ]
     }
   ]

--- a/reductus/sansred/templates/ncnr.sans.default.json
+++ b/reductus/sansred/templates/ncnr.sans.default.json
@@ -11,8 +11,7 @@
         "do_deadtime": true
       },
       "y": 5,
-      "title": "sample",
-      "text_width": 64
+      "title": "sample"
     },
     {
       "x": 10,
@@ -24,8 +23,7 @@
         "do_det_eff": true
       },
       "y": 65,
-      "title": "empty cell",
-      "text_width": 85
+      "title": "empty cell"
     },
     {
       "x": 10,
@@ -37,8 +35,7 @@
         "do_det_eff": true
       },
       "y": 155,
-      "title": "empty trans",
-      "text_width": 96
+      "title": "empty trans"
     },
     {
       "x": 10,
@@ -50,8 +47,7 @@
         "do_det_eff": true
       },
       "y": 125,
-      "title": "sample trans",
-      "text_width": 104
+      "title": "sample trans"
     },
     {
       "x": 200,
@@ -66,8 +62,7 @@
           57.86973180076629,
           72
         ]
-      },
-      "text_width": 80
+      }
     },
     {
       "x": 10,
@@ -79,36 +74,31 @@
         "do_det_eff": true
       },
       "y": 35,
-      "title": "blocked",
-      "text_width": 67
+      "title": "blocked"
     },
     {
       "x": 200,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract",
-      "text_width": 71
+      "title": "Subtract"
     },
     {
       "x": 200,
       "module": "ncnr.sans.subtract",
       "y": 65,
-      "title": "Subtract",
-      "text_width": 71
+      "title": "Subtract"
     },
     {
       "x": 365,
       "module": "ncnr.sans.product",
       "y": 35,
-      "title": "Product",
-      "text_width": 67
+      "title": "Product"
     },
     {
       "x": 525,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract",
-      "text_width": 71
+      "title": "Subtract"
     },
     {
       "x": 895,
@@ -123,8 +113,7 @@
           56,
           73
         ]
-      },
-      "text_width": 83
+      }
     },
     {
       "module": "ncnr.sans.LoadDIV",
@@ -142,8 +131,7 @@
             ]
           }
         ]
-      },
-      "text_width": 36
+      }
     },
     {
       "module": "ncnr.sans.PixelsToQ",
@@ -152,8 +140,7 @@
       "y": 35,
       "config": {
         "correct_solid_angle": true
-      },
-      "text_width": 77
+      }
     },
     {
       "module": "ncnr.sans.circular_av_new",
@@ -163,15 +150,13 @@
       "config": {
         "dQ_method": "IGOR",
         "mask_width": 3
-      },
-      "text_width": 125
+      }
     },
     {
       "module": "ncnr.sans.correct_detector_sensitivity",
       "title": "Div Correction",
       "x": 685,
-      "y": 5,
-      "text_width": 113
+      "y": 5
     },
     {
       "module": "ncnr.sans.SuperLoadSANS",
@@ -181,8 +166,7 @@
       "config": {
         "filelist": [],
         "do_mon_norm": false
-      },
-      "text_width": 132
+      }
     },
     {
       "x": 685,
@@ -197,8 +181,7 @@
           57.86973180076629,
           72
         ]
-      },
-      "text_width": 80
+      }
     }
   ],
   "wires": [

--- a/reductus/sansred/templates/ncnr.sans.default.json
+++ b/reductus/sansred/templates/ncnr.sans.default.json
@@ -11,7 +11,8 @@
         "do_deadtime": true
       },
       "y": 5,
-      "title": "sample"
+      "title": "sample",
+      "text_width": 64
     },
     {
       "x": 10,
@@ -23,7 +24,8 @@
         "do_det_eff": true
       },
       "y": 65,
-      "title": "empty cell"
+      "title": "empty cell",
+      "text_width": 85
     },
     {
       "x": 10,
@@ -34,11 +36,12 @@
         "do_mon_norm": false,
         "do_det_eff": true
       },
-      "y": 140,
-      "title": "open trans"
+      "y": 155,
+      "title": "empty trans",
+      "text_width": 96
     },
     {
-      "x": 5,
+      "x": 10,
       "module": "ncnr.sans.SuperLoadSANS",
       "config": {
         "filelist": [],
@@ -46,13 +49,14 @@
         "do_atten_correct": true,
         "do_det_eff": true
       },
-      "y": 110,
-      "title": "sample trans"
+      "y": 125,
+      "title": "sample trans",
+      "text_width": 104
     },
     {
-      "x": 255,
+      "x": 200,
       "module": "ncnr.sans.generate_transmission",
-      "y": 110,
+      "y": 155,
       "title": "Gen trans",
       "config": {
         "align_by": "",
@@ -62,7 +66,8 @@
           57.86973180076629,
           72
         ]
-      }
+      },
+      "text_width": 80
     },
     {
       "x": 10,
@@ -74,36 +79,41 @@
         "do_det_eff": true
       },
       "y": 35,
-      "title": "blocked"
+      "title": "blocked",
+      "text_width": 67
     },
     {
       "x": 200,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract"
+      "title": "Subtract",
+      "text_width": 71
     },
     {
-      "x": 230,
+      "x": 200,
       "module": "ncnr.sans.subtract",
-      "y": 55,
-      "title": "Subtract"
+      "y": 65,
+      "title": "Subtract",
+      "text_width": 71
     },
     {
-      "x": 380,
+      "x": 365,
       "module": "ncnr.sans.product",
-      "y": 30,
-      "title": "Product"
+      "y": 35,
+      "title": "Product",
+      "text_width": 67
     },
     {
-      "x": 515,
+      "x": 525,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract"
+      "title": "Subtract",
+      "text_width": 71
     },
     {
-      "x": 935,
+      "x": 895,
       "module": "ncnr.sans.absolute_scaling",
-      "y": 50,
+      "y": 35,
       "title": "Abs Scale",
       "config": {
         "auto_box": false,
@@ -113,13 +123,14 @@
           56,
           73
         ]
-      }
+      },
+      "text_width": 83
     },
     {
       "module": "ncnr.sans.LoadDIV",
       "title": "DIV",
-      "x": 590,
-      "y": 140,
+      "x": 525,
+      "y": 65,
       "config": {
         "filelist": [
           {
@@ -131,42 +142,63 @@
             ]
           }
         ]
-      }
+      },
+      "text_width": 36
     },
     {
       "module": "ncnr.sans.PixelsToQ",
       "title": "Pixelstoq",
-      "x": 1085,
-      "y": 50,
+      "x": 1045,
+      "y": 35,
       "config": {
         "correct_solid_angle": true
-      }
+      },
+      "text_width": 77
     },
     {
       "module": "ncnr.sans.circular_av_new",
       "title": "Circular Av New",
-      "x": 1230,
-      "y": 50,
+      "x": 1190,
+      "y": 35,
       "config": {
         "dQ_method": "IGOR",
         "mask_width": 3
-      }
+      },
+      "text_width": 125
     },
     {
       "module": "ncnr.sans.correct_detector_sensitivity",
       "title": "Div Correction",
-      "x": 725,
-      "y": 5
+      "x": 685,
+      "y": 5,
+      "text_width": 113
     },
     {
       "module": "ncnr.sans.SuperLoadSANS",
-      "title": "empty trans",
-      "x": 755,
-      "y": 50,
+      "title": "open beam trans",
+      "x": 480,
+      "y": 155,
       "config": {
         "filelist": [],
         "do_mon_norm": false
-      }
+      },
+      "text_width": 132
+    },
+    {
+      "x": 685,
+      "module": "ncnr.sans.generate_transmission",
+      "y": 95,
+      "title": "Gen trans",
+      "config": {
+        "align_by": "",
+        "integration_box": [
+          58.05363984674328,
+          74,
+          57.86973180076629,
+          72
+        ]
+      },
+      "text_width": 80
     }
   ],
   "wires": [
@@ -282,16 +314,6 @@
     },
     {
       "source": [
-        4,
-        "output"
-      ],
-      "target": [
-        10,
-        "Tsam"
-      ]
-    },
-    {
-      "source": [
         10,
         "abs"
       ],
@@ -348,6 +370,36 @@
       "target": [
         10,
         "empty"
+      ]
+    },
+    {
+      "source": [
+        16,
+        "output"
+      ],
+      "target": [
+        10,
+        "Tsam"
+      ]
+    },
+    {
+      "source": [
+        3,
+        "output"
+      ],
+      "target": [
+        16,
+        "in_beam"
+      ]
+    },
+    {
+      "source": [
+        15,
+        "output"
+      ],
+      "target": [
+        16,
+        "empty_beam"
       ]
     }
   ]

--- a/reductus/sansred/templates/ncnr.sans.default.json
+++ b/reductus/sansred/templates/ncnr.sans.default.json
@@ -162,7 +162,7 @@
       "module": "ncnr.sans.SuperLoadSANS",
       "title": "open beam trans",
       "x": 480,
-      "y": 155,
+      "y": 135,
       "config": {
         "filelist": [],
         "do_mon_norm": false
@@ -187,7 +187,18 @@
       "x": 1375,
       "module": "ncnr.sans.mask_1d_data",
       "y": 35,
-      "title": "Trim Points"
+      "title": "Trim Points",
+      "text_width": 93
+    },
+    {
+      "module": "ncnr.sans.SuperLoadSANS",
+      "title": "config open beam",
+      "x": 705,
+      "y": 153,
+      "config": {
+        "filelist": [],
+        "do_mon_norm": false
+      }
     }
   ],
   "wires": [
@@ -353,16 +364,6 @@
     },
     {
       "source": [
-        15,
-        "output"
-      ],
-      "target": [
-        10,
-        "empty"
-      ]
-    },
-    {
-      "source": [
         16,
         "output"
       ],
@@ -399,6 +400,16 @@
       "target": [
         17,
         "data"
+      ]
+    },
+    {
+      "source": [
+        18,
+        "output"
+      ],
+      "target": [
+        10,
+        "empty"
       ]
     }
   ]


### PR DESCRIPTION
This creates a series of modules to mimic the Igor NSORT capabilities that allow a user to scale a data set (either by a fixed value, or relative to the overlap of another data set), the ability to set the Q limits to cut off the ends where the beamstop and low statistic data are, and to combine any number of data sets into a single 1D data.