### PR TITLE
Display template name in editor window

### DIFF
--- a/reductus/web_gui/webreduce/css/web_reduction_filebrowser.css
+++ b/reductus/web_gui/webreduce/css/web_reduction_filebrowser.css
@@ -392,6 +392,18 @@ div.block-overlay .overlay-positioner {
     justify-content: center;
 }
 
+.editor > #template-title {
+  background: white;
+  padding: 0.1em;
+  border: 3px solid darkgreen;
+  border-radius: 0.25em;
+  font-size: 125%;
+}
+
+.editor > #template-title > span.bold {
+    font-weight: bold;
+}
+
 div.block-overlay .overlay-message {
   background: white;
   padding: 0.5em;

--- a/reductus/web_gui/webreduce/js/editor.js
+++ b/reductus/web_gui/webreduce/js/editor.js
@@ -682,6 +682,7 @@ editor.switch_instrument = async function(instrument_id, load_default=true) {
     if (load_default) {
       app.current_instrument = instrument_id;
       var template_copy = structuredClone(instrument_def.templates[default_template]);
+      template_copy.name = default_template;
       return editor.load_template(template_copy);
     }
   } 

--- a/reductus/web_gui/webreduce/js/main.js
+++ b/reductus/web_gui/webreduce/js/main.js
@@ -294,6 +294,7 @@ async function initialize_app() {
     load_predefined(template_id) {
       let instrument_id = editor._instrument_id;
       const template_copy = structuredClone(editor._instrument_def.templates[template_id]);
+      template_copy.name = template_id;
       editor.load_template(template_copy, null, null, instrument_id);
       // Remember this choice, to be used on next instrument switch:
       try {

--- a/reductus/web_gui/webreduce/js/ui_components/dataflow_viewer.js
+++ b/reductus/web_gui/webreduce/js/ui_components/dataflow_viewer.js
@@ -56,6 +56,10 @@ let dataflow_template = /*html*/`
     </button>
   </div>
 
+  <div v-if="template_data.name != ''" id="template-title">
+    <span class="bold">Active Template:</span> {{template_data.name}}<span v-if="template_data.modified == true"> (modified)</span>
+  </div>
+
   <svg class="dataflow editor" ref="svg">
     <defs>
       <filter id="glow" filterUnits="objectBoundingBox" x="-50%" y="-50%" width="200%" height="200%">
@@ -274,6 +278,8 @@ export const DataflowViewer = {
     template_data: {
       modules: [],
       wires: []
+      wires: [],
+      name: "",
     },
     active_help_tab: 'editing',
     menu: {
@@ -472,10 +478,12 @@ export const DataflowViewer = {
         x: this.menu.x,
         y: this.menu.y
       });
+      this.template_data.modified = true;
       this.menu.visible = false;
     },
     remove_wire(index) {
       this.template_data.wires.splice(index, 1);
+      this.template_data.modified = true;
       this.on_change();
     },
     remove_module(index) {
@@ -527,6 +535,7 @@ export const DataflowViewer = {
       }
 
       //console.log(JSON.stringify(this.template_data.wires, null, 2));
+      this.template_data.modified = true;
       this.on_change();
     },
     copy_module(index) {
@@ -557,6 +566,7 @@ export const DataflowViewer = {
       if (new_title != null) {
         module.title = new_title;
       }
+      this.template_data.modified = true;
       this.$nextTick(() => this.$refs.modules[index].set_display_width());
     },
     show_help() {

--- a/reductus/web_gui/webreduce/js/ui_components/dataflow_viewer.js
+++ b/reductus/web_gui/webreduce/js/ui_components/dataflow_viewer.js
@@ -277,9 +277,9 @@ export const DataflowViewer = {
     instrument_def: {},
     template_data: {
       modules: [],
-      wires: []
       wires: [],
       name: "",
+      modified: false
     },
     active_help_tab: 'editing',
     menu: {


### PR DESCRIPTION
I was having trouble knowing what template was in use when I would work in reductus and can imagine, I'm not the only person with the same issue. This change shows the name of the template currently in use in the workflow editor pane. If any change is made to the template, `(modified)` is added to the title to let users know something has changed.

Things to improve:

- The editor pane is still the same size as before, despite the added element (couldn't find where to expand the section in the CSS)
- The `modified` value should track the current template relative to the original template. Currently, any time a change is made, even if that change is eventually reverted, the template is labelled as modified and is never changed back.