### PR TITLE
Allow specifying data source certificate in config

### DIFF
--- a/provisioning/ubuntu22/config.py
+++ b/provisioning/ubuntu22/config.py
@@ -41,10 +41,11 @@ config = {
     "data_sources": [
         {
             "name": "ncnr",
-            "url": "https://www.ncnr.nist.gov/pub/",
+            "url": "https://awswebster.ncnr.nist.gov/pub/",
+            "cert": "/home/bbm/reductus-work/NIST_bundle.pem",
             "start_path": "ncnrdata",
-            "file_helper_url": "http://10.201.1.148/ncnrdata/listftpfiles_pg.php",
-            "file_helper_cert": "/home/ubuntu/reductus-work/NIST_bundle.pem"
+            "file_helper_url": "https://awswebster.ncnr.nist.gov/ncnrdata/listftpfiles_pg.php",
+            "file_helper_cert": "/home/bbm/reductus-work/NIST_bundle.pem"
         },
     ],
     "startup_banner": {

--- a/reductus/dataflow/fetch.py
+++ b/reductus/dataflow/fetch.py
@@ -76,7 +76,8 @@ def check_datasource(source):
     else:
         source_url = ""
         raise RuntimeError("Must have url specified for data source: " + source + " in config.")
-    return source_url
+    source_cert = datasource.get("cert", None)
+    return source_url, source_cert
 
 
 def url_get(fileinfo, mtime_check=True):
@@ -101,12 +102,12 @@ def url_get(fileinfo, mtime_check=True):
             print("getting " + path + " from cache!")
         else:
             name = basename(path)
-            source_url = check_datasource(source)
+            source_url, source_cert = check_datasource(source)
             full_url = join(source_url, urllib.parse.quote(path.strip(sep), safe='/:'))
             print("loading", full_url, name)
             req = None  # Need placeholder for req in case requests.get fails.
             try:
-                req = requests.get(full_url)
+                req = requests.get(full_url, verify=source_cert)
                 req.raise_for_status()
                 url_mtime = req.headers.get('last-modified', None)
                 url_time_struct = time.strptime(url_mtime, '%a, %d %b %Y %H:%M:%S %Z')


### PR DESCRIPTION
Add a new optional configuration key for a datasource, 'cert', that contains a path to the certificate chain to be used for datafile requests from the defined 'url' in the configuration.

Works the same as the 'file_helper_url' and 'file_helper_cert' pair in the datasource config.