### PR TITLE
get dimensions of array from shape 

### DIFF
--- a/reductus/vsansred/steps.py
+++ b/reductus/vsansred/steps.py
@@ -2,6 +2,7 @@ from posixpath import basename, join
 from copy import copy, deepcopy
 from io import BytesIO
 import sys
+import warnings
 import numpy as np
 
 from reductus.dataflow.lib.uncertainty import Uncertainty
@@ -639,6 +640,15 @@ def calculate_XY(raw_data, solid_angle_correction=True):
         detname = 'detector_{short_name}'.format(short_name=sn)
         det = deepcopy(raw_data.detectors[detname])
 
+        data = det['data']['value']
+        dimX, dimY = data.shape[-2:]
+        expected_dimX = int(det['pixel_num_x']['value'][0])
+        expected_dimY = int(det['pixel_num_y']['value'][0])
+        if dimX != expected_dimX:
+            warnings.warn(f"shape[0] of loaded array ({dimX}) does not match expected shape ({expected_dimX})")
+        if dimY != expected_dimY:
+            warnings.warn(f"shape[1] of loaded array ({dimY}) does not match expected shape ({expected_dimY})")
+
         z_offset = det.get('setback', {"value": [0.0]})['value'][0]
         z = det['distance']['value'][0] + z_offset
 
@@ -664,8 +674,6 @@ def calculate_XY(raw_data, solid_angle_correction=True):
             realDistX =  0.5 * x_pixel_size
             realDistY =  0.5 * y_pixel_size
 
-            data = det['data']['value']
-            dimX, dimY = data.shape[-2:]
             if 'linear_data_error' in det and 'value' in det['linear_data_error']:
                 data_variance = np.sqrt(det['linear_data_error']['value'])
             else:
@@ -692,8 +700,6 @@ def calculate_XY(raw_data, solid_angle_correction=True):
                 vertical_offset = det['vertical_offset']['value'][0] # already cm
 
             #solid_angle_correction = z*z / 1e6
-            data = det['data']['value']
-            dimX, dimY = data.shape[-2:]
             if 'linear_data_error' in det and 'value' in det['linear_data_error']:
                 data_variance = np.sqrt(det['linear_data_error']['value'])
             else:

--- a/reductus/vsansred/steps.py
+++ b/reductus/vsansred/steps.py
@@ -639,8 +639,6 @@ def calculate_XY(raw_data, solid_angle_correction=True):
         detname = 'detector_{short_name}'.format(short_name=sn)
         det = deepcopy(raw_data.detectors[detname])
 
-        dimX = int(det['pixel_num_x']['value'][0])
-        dimY = int(det['pixel_num_y']['value'][0])
         z_offset = det.get('setback', {"value": [0.0]})['value'][0]
         z = det['distance']['value'][0] + z_offset
 
@@ -667,6 +665,7 @@ def calculate_XY(raw_data, solid_angle_correction=True):
             realDistY =  0.5 * y_pixel_size
 
             data = det['data']['value']
+            dimX, dimY = data.shape[-2:]
             if 'linear_data_error' in det and 'value' in det['linear_data_error']:
                 data_variance = np.sqrt(det['linear_data_error']['value'])
             else:
@@ -694,6 +693,7 @@ def calculate_XY(raw_data, solid_angle_correction=True):
 
             #solid_angle_correction = z*z / 1e6
             data = det['data']['value']
+            dimX, dimY = data.shape[-2:]
             if 'linear_data_error' in det and 'value' in det['linear_data_error']:
                 data_variance = np.sqrt(det['linear_data_error']['value'])
             else:


### PR DESCRIPTION
For some reason we were getting the shape of the detector from separate fields 'pixel_num_x' and 'pixel_num_y' instead of just looking at the shape

This fixes a problem where currently those fields (written from nexus config) are incorrect.  We don't really need them anyway.